### PR TITLE
No longer manually starting / ending run loop for Stripe request.

### DIFF
--- a/app/services/stripe.js
+++ b/app/services/stripe.js
@@ -8,9 +8,6 @@ function createToken (card) {
     Ember.Logger.info('StripeService: getStripeToken - card:', card);
   }
 
-  // manually start Ember loop
-  Ember.run.begin();
-
   return new Ember.RSVP.Promise(function (resolve, reject) {
     Stripe.card.createToken(card, function (status, response) {
 
@@ -20,12 +17,10 @@ function createToken (card) {
 
       if (response.error) {
         reject(response);
-        return Ember.run.end();
       }
 
       resolve(response);
 
-      Ember.run.end();
     });
   });
 }


### PR DESCRIPTION
Using Ember.run.begin() before making the Stripe request prevents the UI to update with any pending changes until the Ember.run.end() is called.  This is problematic in case you want to show a spinner while the Stripe request is happening.

Here's a jsbin that demonstrates this:
http://jsbin.com/qacava/1/edit?html,js,output
  * clicking the `Without Run Loop` button will display proper messages while running a long task
  * clicking the `With Run Loop` button will suppress message changes

What was the reason for manually starting the Ember loop?

It seems to work fine (both resolve and reject) without the manual Ember loop. 