### PR TITLE
Create bank account tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ## Features
 - sets stripe.js script in index.html (test, app)
 - initializes stripe with publishable key
-- injects service in controllers which provides promisified method for `Stripe.createToken`
+- injects service in controllers which provides promisified method for `Stripe.card.createToken`
 - provides debugging logs for easy troubleshooting
 
 ## Installation
@@ -32,9 +32,12 @@ ENV.stripe = {
 
 ## Creating Stripe Tokens for Cards
 
-`ember-stripe-service` provides a promisified version of `Stripe.createToken` which makes it easier to interact with its returns within your Ember controllers.
+`ember-stripe-service` provides a promisified version of
+`Stripe.card.createToken` which makes it easier to interact with its returns
+within your Ember controllers.
 
-The method makes createToken operate under Ember run's loop making it easier to create integration tests that operate with Stripe's test mode.
+The method makes `createToken` operate under Ember run's loop making it easier
+to create integration tests that operate with Stripe's test mode.
 
 To use it inside of a controller action or method you would:
 
@@ -52,7 +55,7 @@ export default Ember.Controller.extend({
     // if for example you had the cc set in your controller
     var card = this.get('creditCard');
 
-    return stripe.createToken(card).then(function(response) {
+    return stripe.card.createToken(card).then(function(response) {
       // you get access to your newly created token here
       customer.set('stripeToken', response.id);
       return customer.save();
@@ -72,7 +75,7 @@ export default Ember.Controller.extend({
 ````
 ## Creating Stripe Tokens for Bank Accounts
 
-The interface is similar for bank accounts:
+The interface is similar for bank account tokens:
 
 ````javascript
 
@@ -86,7 +89,7 @@ The interface is similar for bank accounts:
       accountNumber: '23875292349'
     }
 
-    return stripe.createBankAccountToken(bankAccount).then(function(response) {
+    return stripe.bankAccount.createToken(bankAccount).then(function(response) {
       // you get access to your newly created token here
       customer.set('bankAccountStripeToken', response.id);
       return customer.save();
@@ -102,7 +105,7 @@ The interface is similar for bank accounts:
 })
 ````
 
-## Debbuging
+## Debugging
 By setting `LOG_STRIPE_SERVICE` to true in your application configuration you can enable some debugging messages from the service
 
 ````javascript

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ ENV.stripe = {
 };
 ````
 
-## Creating Stripe Tokens
+## Creating Stripe Tokens for Cards
 
 `ember-stripe-service` provides a promisified version of `Stripe.createToken` which makes it easier to interact with its returns within your Ember controllers.
 
@@ -65,6 +65,37 @@ export default Ember.Controller.extend({
 
       if (response.error.type === 'card_error') {
         // show the error in the form or something
+      }
+    }
+  }
+})
+````
+## Creating Stripe Tokens for Bank Accounts
+
+The interface is similar for bank accounts:
+
+````javascript
+
+    // obtain access to the injected service
+    var stripe = this.get('stripe');
+
+    // if for example you had the cc set in your controller
+    var bankAccount = {
+      country: 'US',
+      routingNumber: '1235678',
+      accountNumber: '23875292349'
+    }
+
+    return stripe.createBankAccountToken(bankAccount).then(function(response) {
+      // you get access to your newly created token here
+      customer.set('bankAccountStripeToken', response.id);
+      return customer.save();
+    })
+    .catch(response) {
+      // if there was an error retrieving the token you could get it here
+
+      if (response.error.type === 'invalid_request_error') {
+        // show an error in the form
       }
     }
   }

--- a/app/services/stripe.js
+++ b/app/services/stripe.js
@@ -3,7 +3,7 @@ import config from '../config/environment';
 import Ember from 'ember';
 var debug = config.LOG_STRIPE_SERVICE;
 
-function createToken (card) {
+function createCardToken (card) {
   if (debug) {
     Ember.Logger.info('StripeService: getStripeToken - card:', card);
   }
@@ -15,7 +15,7 @@ function createToken (card) {
     Stripe.card.createToken(card, function (status, response) {
 
       if (debug) {
-        Ember.Logger.info('StripeService: createToken handler - status %s, response:', status, response);
+        Ember.Logger.info('StripeService: card.createToken handler - status %s, response:', status, response);
       }
 
       if (response.error) {
@@ -30,6 +30,13 @@ function createToken (card) {
   });
 }
 
+function createCardTokenDeprecated(card) {
+  Ember.deprecate('`EmberStripeService.createToken` has been deprecated in ' +
+                  'favour of `EmberStripeService.card.createToken` to match ' +
+                  'the Stripe API.');
+  return createCardToken(card);
+}
+
 function createBankAccountToken(bankAccount) {
   if (debug) {
     Ember.Logger.info('StripeService: getStripeToken - bankAccount:', bankAccount);
@@ -42,7 +49,7 @@ function createBankAccountToken(bankAccount) {
     Stripe.bankAccount.createToken(bankAccount, function (status, response) {
 
       if (debug) {
-        Ember.Logger.info('StripeService: createBankAccountToken handler - status %s, response:', status, response);
+        Ember.Logger.info('StripeService: bankAccount.createToken handler - status %s, response:', status, response);
       }
 
       if (response.error) {
@@ -58,6 +65,11 @@ function createBankAccountToken(bankAccount) {
 }
 
 export default Ember.Object.extend({
-  createToken: createToken,
-  createBankAccountToken: createBankAccountToken,
+  createToken: createCardTokenDeprecated,
+  card: {
+    createToken: createCardToken,
+  },
+  bankAccount: {
+    createToken: createBankAccountToken,
+  }
 });

--- a/app/services/stripe.js
+++ b/app/services/stripe.js
@@ -30,6 +30,34 @@ function createToken (card) {
   });
 }
 
+function createBankAccountToken(bankAccount) {
+  if (debug) {
+    Ember.Logger.info('StripeService: getStripeToken - bankAccount:', bankAccount);
+  }
+
+  // manually start Ember loop
+  Ember.run.begin();
+
+  return new Ember.RSVP.Promise(function (resolve, reject) {
+    Stripe.bankAccount.createToken(bankAccount, function (status, response) {
+
+      if (debug) {
+        Ember.Logger.info('StripeService: createBankAccountToken handler - status %s, response:', status, response);
+      }
+
+      if (response.error) {
+        reject(response);
+        return Ember.run.end();
+      }
+
+      resolve(response);
+
+      Ember.run.end();
+    });
+  });
+}
+
 export default Ember.Object.extend({
-  createToken: createToken
+  createToken: createToken,
+  createBankAccountToken: createBankAccountToken,
 });

--- a/tests/unit/services/stripe-test.js
+++ b/tests/unit/services/stripe-test.js
@@ -17,7 +17,47 @@ var cc = {
   address_zip: 12345
 };
 
-test('createToken sets the token and returns a promise', function(assert) {
+test('card.createToken sets the token and returns a promise', function(assert) {
+  var service = this.subject();
+  var response = {
+    id: 'the_token'
+  };
+
+  var createToken = sinon.stub(Stripe.card, 'createToken', function(card, cb) {
+    assert.equal(card, cc, 'called with sample creditcard');
+    cb(200, response);
+  });
+
+  return service.card.createToken(cc)
+    .then(function(res) {
+      assert.equal(res.id, 'the_token');
+      createToken.restore();
+    });
+});
+
+test('card.createToken rejects the promise if Stripe errors', function(assert) {
+  var service = this.subject();
+  var response = {
+    error : {
+      code: "invalid_number",
+      message: "The 'exp_month' parameter should be an integer (instead, is Month).",
+      param: "exp_month",
+      type: "card_error"
+    }
+  };
+
+  var createToken = sinon.stub(Stripe.card, 'createToken', function(card, cb) {
+    cb(402, response);
+  });
+
+  return service.card.createToken(cc)
+  .then(undefined, function(res) {
+    assert.equal(res, response, 'error passed');
+    createToken.restore();
+  });
+});
+
+test('createToken syntax is still supported', function(assert) {
   var service = this.subject();
   var response = {
     id: 'the_token'
@@ -35,28 +75,6 @@ test('createToken sets the token and returns a promise', function(assert) {
     });
 });
 
-test('createToken rejects the promise if Stripe errors', function(assert) {
-  var service = this.subject();
-  var response = {
-    error : {
-      code: "invalid_number",
-      message: "The 'exp_month' parameter should be an integer (instead, is Month).",
-      param: "exp_month",
-      type: "card_error"
-    }
-  };
-
-  var createToken = sinon.stub(Stripe.card, 'createToken', function(card, cb) {
-    cb(402, response);
-  });
-
-  return service.createToken(cc)
-  .then(undefined, function(res) {
-    assert.equal(res, response, 'error passed');
-    createToken.restore();
-  });
-});
-
 // Bank accounts
 
 var ba = {
@@ -65,7 +83,7 @@ var ba = {
   accountNumber: '125677688',
 };
 
-test('createBankAccountToken sets the token and returns a promise', function(assert) {
+test('bankAccount.createToken sets the token and returns a promise', function(assert) {
   var service = this.subject();
   var response = {
     id: 'the_token'
@@ -78,14 +96,14 @@ test('createBankAccountToken sets the token and returns a promise', function(ass
     cb(200, response);
   });
 
-  return service.createBankAccountToken(ba)
+  return service.bankAccount.createToken(ba)
     .then(function(res) {
       assert.equal(res.id, 'the_token');
       createBankAccountToken.restore();
     });
 });
 
-test('createBankAccountToken rejects the promise if Stripe errors', function(assert) {
+test('bankAccount.createToken rejects the promise if Stripe errors', function(assert) {
   var service = this.subject();
   var response = {
     error : {
@@ -102,7 +120,7 @@ test('createBankAccountToken rejects the promise if Stripe errors', function(ass
     cb(402, response);
   });
 
-  return service.createBankAccountToken(ba)
+  return service.bankAccount.createToken(ba)
   .then(undefined, function(res) {
     assert.equal(res, response, 'error passed');
     createBankAccountToken.restore();

--- a/tests/unit/services/stripe-test.js
+++ b/tests/unit/services/stripe-test.js
@@ -57,6 +57,59 @@ test('createToken rejects the promise if Stripe errors', function(assert) {
   });
 });
 
+// Bank accounts
+
+var ba = {
+  country: 'US',
+  routingNumber: '123124112',
+  accountNumber: '125677688',
+};
+
+test('createBankAccountToken sets the token and returns a promise', function(assert) {
+  var service = this.subject();
+  var response = {
+    id: 'the_token'
+  };
+
+  var createBankAccountToken = sinon.stub(Stripe.bankAccount,
+                                          'createBankAccountToken',
+                                          function(bankAccount, cb) {
+    assert.equal(bankAccount, ba, 'called with sample bankAccount');
+    cb(200, response);
+  });
+
+  return service.createBankAccountToken(ba)
+    .then(function(res) {
+      assert.equal(res.id, 'the_token');
+      createBankAccountToken.restore();
+    });
+});
+
+test('createBankAccountToken rejects the promise if Stripe errors', function(assert) {
+  var service = this.subject();
+  var response = {
+    error : {
+      code: "invalid_number",
+      message: "The 'exp_month' parameter should be an integer (instead, is Month).",
+      param: "exp_month",
+      type: "bank_account_errror"
+    }
+  };
+
+  var createBankAccountToken = sinon.stub(Stripe.bankAccount,
+                                          'createBankAccountToken',
+                                          function(bankAccount, cb) {
+    cb(402, response);
+  });
+
+  return service.createBankAccountToken(ba)
+  .then(undefined, function(res) {
+    assert.equal(res, response, 'error passed');
+    createBankAccountToken.restore();
+  });
+});
+
+
 // LOG_STRIPE_SERVICE is set to true in dummy app
 test('it logs when LOG_STRIPE_SERVICE is set in env config', function(assert) {
   var service = this.subject();

--- a/tests/unit/services/stripe-test.js
+++ b/tests/unit/services/stripe-test.js
@@ -72,7 +72,7 @@ test('createBankAccountToken sets the token and returns a promise', function(ass
   };
 
   var createBankAccountToken = sinon.stub(Stripe.bankAccount,
-                                          'createBankAccountToken',
+                                          'createToken',
                                           function(bankAccount, cb) {
     assert.equal(bankAccount, ba, 'called with sample bankAccount');
     cb(200, response);
@@ -97,7 +97,7 @@ test('createBankAccountToken rejects the promise if Stripe errors', function(ass
   };
 
   var createBankAccountToken = sinon.stub(Stripe.bankAccount,
-                                          'createBankAccountToken',
+                                          'createToken',
                                           function(bankAccount, cb) {
     cb(402, response);
   });


### PR DESCRIPTION
Use the similar interface `Stripe.bankAccount.createToken` to register bank accounts.

Update:

Moves the createToken to be namespaced to match the stripe service and deprecates old usage:

     EmberStripeService.card.createToken

Adds a method for creating bank account tokens

     EmberStripeService.bankAccount.createToken