### PR TITLE
Simplify run-loop handling for `createToken`

### DIFF
--- a/app/services/stripe.js
+++ b/app/services/stripe.js
@@ -8,9 +8,6 @@ function createToken (card) {
     Ember.Logger.info('StripeService: getStripeToken - card:', card);
   }
 
-  // manually start Ember loop
-  Ember.run.begin();
-
   return new Ember.RSVP.Promise(function (resolve, reject) {
     Stripe.card.createToken(card, function (status, response) {
 
@@ -19,13 +16,10 @@ function createToken (card) {
       }
 
       if (response.error) {
-        reject(response);
-        return Ember.run.end();
+        Ember.run(null, reject, response);
+      } else {
+        Ember.run(null, resolve, response);
       }
-
-      resolve(response);
-
-      Ember.run.end();
     });
   });
 }


### PR DESCRIPTION
The run-loop only needs to run when resolving/rejecting, it's also less code which is always good!