### PR TITLE
Export subclass of Ember.Service, run loops

### DIFF
--- a/app/services/stripe.js
+++ b/app/services/stripe.js
@@ -64,7 +64,7 @@ function createBankAccountToken(bankAccount) {
   });
 }
 
-export default Ember.Object.extend({
+export default Ember.Service.extend({
   createToken: createCardTokenDeprecated,
   card: {
     createToken: createCardToken,

--- a/app/services/stripe.js
+++ b/app/services/stripe.js
@@ -15,7 +15,11 @@ function createCardToken (card) {
         Ember.Logger.info('StripeService: card.createToken handler - status %s, response:', status, response);
       }
 
-      Ember.run(null, response.error ? reject : resolve, response);
+      if (response.error) {
+        Ember.run(null, reject, response);
+      } else {
+        Ember.run(null, resolve, response);
+      }
     });
   });
 }
@@ -39,7 +43,11 @@ function createBankAccountToken(bankAccount) {
         Ember.Logger.info('StripeService: bankAccount.createToken handler - status %s, response:', status, response);
       }
 
-      Ember.run(null, response.error ? reject : resolve, response);
+      if (response.error) {
+        Ember.run(null, reject, response);
+      } else {
+        Ember.run(null, resolve, response);
+      }
     });
   });
 }

--- a/app/services/stripe.js
+++ b/app/services/stripe.js
@@ -8,9 +8,6 @@ function createCardToken (card) {
     Ember.Logger.info('StripeService: getStripeToken - card:', card);
   }
 
-  // manually start Ember loop
-  Ember.run.begin();
-
   return new Ember.RSVP.Promise(function (resolve, reject) {
     Stripe.card.createToken(card, function (status, response) {
 
@@ -18,14 +15,7 @@ function createCardToken (card) {
         Ember.Logger.info('StripeService: card.createToken handler - status %s, response:', status, response);
       }
 
-      if (response.error) {
-        reject(response);
-        return Ember.run.end();
-      }
-
-      resolve(response);
-
-      Ember.run.end();
+      Ember.run(null, response.error ? reject : resolve, response);
     });
   });
 }
@@ -42,9 +32,6 @@ function createBankAccountToken(bankAccount) {
     Ember.Logger.info('StripeService: getStripeToken - bankAccount:', bankAccount);
   }
 
-  // manually start Ember loop
-  Ember.run.begin();
-
   return new Ember.RSVP.Promise(function (resolve, reject) {
     Stripe.bankAccount.createToken(bankAccount, function (status, response) {
 
@@ -52,14 +39,7 @@ function createBankAccountToken(bankAccount) {
         Ember.Logger.info('StripeService: bankAccount.createToken handler - status %s, response:', status, response);
       }
 
-      if (response.error) {
-        reject(response);
-        return Ember.run.end();
-      }
-
-      resolve(response);
-
-      Ember.run.end();
+      Ember.run(null, response.error ? reject : resolve, response);
     });
   });
 }


### PR DESCRIPTION
Ember 1.13.0-beta.2 expects service to be a subclass of Ember.Service.

`Uncaught Error: Assertion Failed: Expected service:stripe to resolve to an Ember.Service but instead it was (unknown mixin).`

See also [https://github.com/emberjs/ember.js/issues/11292](https://github.com/emberjs/ember.js/issues/11292).

There is only deprecation instead of assert in Ember Canary, but this is definitely more future-proof.

Also, simplified run loops as mentioned in #17.