### PR TITLE
WIP: Allow lazy-loading stripe.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,35 @@ ENV.stripe = {
 };
 ````
 
+### Lazy Loading of `stripe.js`
+
+By default, `ember-stripe-service` loads the `stripe.js` library during app initialization. If you want to load the script lazily in order to improve boot
+performance, set `lazyLoad: true`:
+```javascript
+ENV.stripe = {
+  publishableKey: 'pk_thisIsATestKey',
+  lazyLoad: true
+};
+```
+
+`ember-stripe-service` will fetch `stripe.js` the first time it is needed.
+
+You can ensure it's ready before then by calling `stripeService.getScript()`.
+For example,
+
+```javascript
+// app/routes/payment.js
+
+stripe: Ember.inject.service(),
+
+afterModel: function() {
+  return this.get('stripe').getScript();
+}
+```
+
+It is safe to call `getScript` multiple times. If `Stripe` is already loaded,
+it will return a Promise that resolves immediately.
+
 ## Creating Stripe Tokens for Cards
 
 `ember-stripe-service` provides a promisified version of

--- a/addon/get-stripe-library.js
+++ b/addon/get-stripe-library.js
@@ -1,0 +1,29 @@
+/* global Stripe */
+import $ from 'jquery';
+import Ember from 'ember';
+
+var inflight;
+
+export default function getStripeLibrary(publishableKey) {
+  if (typeof Stripe !== 'undefined') {
+    return Ember.RSVP.resolve(Stripe);
+  }
+
+  if (inflight) { return inflight; }
+
+  inflight = new Ember.RSVP.Promise(function (resolve, reject) {
+    const url = 'https://js.stripe.com/v2/';
+    $.ajax({
+      dataType: "script",
+      cache: true,
+      url: url
+    }).then(
+      function() {
+        tripe.setPublishableKey(publishableKey);
+        resolve(Stripe);
+      },
+      function() { reject("Failed to load Stripe library"); }
+    );
+  })
+  .finally(function() { inflight = null; });
+}

--- a/app/initializers/stripe-service.js
+++ b/app/initializers/stripe-service.js
@@ -1,6 +1,7 @@
-/* global Stripe */
 import Ember from 'ember';
 import config from '../config/environment';
+import getStripeLibrary from 'ember-stripe-service/get-stripe-library';
+
 var debug = config.LOG_STRIPE_SERVICE;
 
 export function initialize() {
@@ -12,7 +13,9 @@ export function initialize() {
     throw new Ember.Error('StripeService: Missing Stripe key, please set `ENV.stripe.publishableKey` in config.environment.js');
   }
 
-  Stripe.setPublishableKey(config.stripe.publishableKey);
+  if (!config.stripe.lazyLoad) {
+    return getStripeLibrary(config.stripe.publishableKey);
+  }
 }
 
 export default {

--- a/app/services/stripe.js
+++ b/app/services/stripe.js
@@ -1,6 +1,6 @@
-/* global Stripe */
 import env from '../config/environment';
 import Ember from 'ember';
+import getStripeLibrary from "ember-stripe-service/get-stripe-library";
 
 /**
  * Uses Ember.Logger.info to output service information if LOG_STRIPE_SERVICE is
@@ -31,17 +31,19 @@ function debug() {
 function createCardToken (card) {
   debug('card.createToken:', card);
 
-  return new Ember.RSVP.Promise(function (resolve, reject) {
-    Stripe.card.createToken(card, function (status, response) {
+  return getStripeLibrary().then(function(Stripe) {
+    return new Ember.RSVP.Promise(function (resolve, reject) {
+      Stripe.card.createToken(card, function (status, response) {
 
-      debug('card.createToken handler - status %s, response:', status, response);
+        debug('card.createToken handler - status %s, response:', status, response);
 
-      if (response.error) {
-        return Ember.run(null, reject, response);
-      }
+        if (response.error) {
+          return Ember.run(null, reject, response);
+        }
 
-      Ember.run(null, resolve, response);
+        Ember.run(null, resolve, response);
 
+      });
     });
   });
 }
@@ -56,16 +58,18 @@ function createCardToken (card) {
 function createBankAccountToken(bankAccount) {
   debug('bankAccount.createToken:', bankAccount);
 
-  return new Ember.RSVP.Promise(function (resolve, reject) {
-    Stripe.bankAccount.createToken(bankAccount, function (status, response) {
+  return getStripeLibrary().then(function(Stripe) {
+    return new Ember.RSVP.Promise(function (resolve, reject) {
+      Stripe.bankAccount.createToken(bankAccount, function (status, response) {
 
-      debug('bankAccount.createToken handler - status %s, response:', status, response);
+        debug('bankAccount.createToken handler - status %s, response:', status, response);
 
-      if (response.error) {
-        return Ember.run(null, reject, response);
-      }
+        if (response.error) {
+          return Ember.run(null, reject, response);
+        }
 
-      Ember.run(null, resolve, response);
+        Ember.run(null, resolve, response);
+      });
     });
   });
 }
@@ -79,5 +83,8 @@ export default Ember.Service.extend({
   },
   bankAccount: {
     createToken: createBankAccountToken,
+  },
+  getScript: function() {
+    return getStripeLibrary(env.stripe.publishableKey);
   }
 });

--- a/index.js
+++ b/index.js
@@ -2,11 +2,5 @@
 'use strict';
 
 module.exports = {
-  name: 'stripe-service',
-  contentFor: function(type) {
-    // we use body since Stripe must be available before
-    if (type === 'body') {
-      return '<script type="text/javascript" src="https://js.stripe.com/v2/"></script>';
-    }
-  }
+  name: 'stripe-service'
 };


### PR DESCRIPTION
:no_entry: This is a work-in-progress. I haven't yet come up with a good way to test this behavior. This PR also makes clear that the tests were relying on the `<script>` tag actually loading the real Stripe service instead of mocking `window.Stripe`.

 1. stop inserting `<script>` tag into body
 1. add `ember-stripe-service/get-stripe-library`, which returns a Promise that resolves when `Stripe` is ready. If it's already fetched, it resolves immediately. Otherwise, it fetches then resolves.
 1. expose `stripeService.getScript()` to load `stripe.js` manually
 1. `initializer:stripe-service` blocks on `getStripeLibrary()` by default. This preserves the existing fetch-on-load behavior.
 1. add `lazyLoad: true` option to turn off eager loading in the initializer

Resolves #20