### PR TITLE
wrap error code in Ember.Error on reject

### DIFF
--- a/app/services/stripe.js
+++ b/app/services/stripe.js
@@ -37,11 +37,10 @@ function createCardToken (card) {
       debug('card.createToken handler - status %s, response:', status, response);
 
       if (response.error) {
-        return Ember.run(null, reject, response);
+        return Ember.run(null, reject, new Ember.Error(response.error.code));
       }
 
       Ember.run(null, resolve, response);
-
     });
   });
 }


### PR DESCRIPTION
Wrap errors from Stripe in `Ember.Error`. We want to be able to write tests for handling errors for Stripe. If we just reject with the error object then our tests we always fail. So instead we need to wrap the test in an Ember.Error object.

Fixes #30 See the discussion in that issue.