### PR TITLE
[feature] Stripe Credit Card and Bank Account Validations

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,41 @@ The interface is similar for bank account tokens:
 })
 ````
 
+## Client-side validation helpers
+Validations return true if Credit Card Number and Bank Account Number are POTENTIALLY valid, false instead.
+
+```javascript
+var attr = DS.attr;
+export default DS.Model.extend({
+  stripe: Ember.inject.service(),
+  cardNumber: attr('string'),
+  cardValidation: function () {
+    var card = this.get('stripe.card');
+    if (!card.validateCardNumber(this.get('cardNumber'))) {
+      throw 'Invalid credit card cardNumber';
+    }
+  },
+  type: function () {
+    var card = this.get('stripe.card');
+    return card.cardType(this.get('cardNumber'));
+  }.property('cardNumber'),
+  // ...
+  routingNumber: attr('string'),
+  accountNumber: attr('string'),
+  country: attr('string'),
+  bankAccountValidation: function () {
+    var bankAccount = this.get('stripe.bankAccount');
+    return bankAccount.validateRoutingNumber(this.get('routingNumber'), this.get('country')) &&
+            bankAccount.validateAccountNumber(this.get('accountNumber'), this.get('country'));
+  },
+...
+// other validations are
+// validateCardNumber
+// validateCVC
+// validateExpiry
+});
+```
+
 ## Debugging
 By setting `LOG_STRIPE_SERVICE` to true in your application configuration you can enable some debugging messages from the service
 

--- a/app/services/stripe.js
+++ b/app/services/stripe.js
@@ -76,8 +76,14 @@ function createBankAccountToken(bankAccount) {
 export default Ember.Service.extend({
   card: {
     createToken: createCardToken,
+    cardType: Stripe.card.cardType,
+    validateCardNumber: Stripe.card.validateCardNumber,
+    validateCVC: Stripe.card.validateCVC,
+    validateExpiry: Stripe.card.validateExpiry
   },
   bankAccount: {
     createToken: createBankAccountToken,
+    validateRoutingNumber: Stripe.bankAccount.validateRoutingNumber,
+    validateAccountNumber: Stripe.bankAccount.validateAccountNumber
   }
 });

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -6,4 +6,5 @@ var Router = Ember.Router.extend({
 });
 
 export default Router.map(function() {
+  this.route('checkout', {path: '/'});
 });

--- a/tests/dummy/app/routes/checkout.js
+++ b/tests/dummy/app/routes/checkout.js
@@ -1,0 +1,28 @@
+import Ember from "ember";
+
+export default Ember.Route.extend({
+  // activate: function() {},
+  // deactivate: function() {},
+  // setupController: function(controller, model) {},
+  // renderTemplate: function() {},
+  // beforeModel: function() {},
+  // afterModel: function() {},
+  stripe: Ember.inject.service(),
+  actions: {
+    checkout: function () {
+      var customer = Ember.Object.create({
+        stripeToken: null,
+        sayHi: () => { return 'HI'; }
+      });
+      this.get('stripe').card.createToken({
+        number: '4111 1111 1111 1111',
+        exp_month: '02',
+        exp_year: '2020',
+        address_zip: '12345'
+      }).then((response) => {
+        customer.set('stripeToken', response.id);
+        this.controller.set('token', response.id);
+      });
+    }
+  }
+});

--- a/tests/dummy/app/templates/checkout.hbs
+++ b/tests/dummy/app/templates/checkout.hbs
@@ -1,0 +1,2 @@
+<button {{action "checkout"}} id="checkout">Submit</button>
+<p class="text">Customer Token: <b id="token">{{token}}</b></p>

--- a/tests/integration/stripe-app-test.js
+++ b/tests/integration/stripe-app-test.js
@@ -1,0 +1,24 @@
+import Ember from "ember";
+import startApp from '../helpers/start-app';
+import {module, test} from 'qunit';
+
+module("Integration - Stripe - Checkout", {
+  beforeEach: function() {
+    this.App = startApp();
+  },
+  afterEach: function() {
+    Ember.run(this.App, 'destroy');
+  }
+});
+
+test('it creates token and set\'s it to customer', function (assert) {
+  visit('/');
+
+  andThen(() => {
+    return click('#checkout');
+  });
+
+  andThen(() => {
+    assert.ok(find('.text #token').text().length > 0, 'token is not empty');
+  });
+});

--- a/tests/integration/stripe-test.js
+++ b/tests/integration/stripe-test.js
@@ -29,7 +29,7 @@ test('card.createToken sets the token and returns a promise', function(assert) {
 
   return service.card.createToken(cc)
   .then(function(res) {
-    assert.ok(res.id, 'correct token set');
+    assert.ok(!!res.id, 'correct token set');
   });
 });
 
@@ -38,7 +38,7 @@ test('bankAccount.createToken sets the token and returns a promise', function(as
 
   return service.bankAccount.createToken(bankAccount)
   .then(function(res) {
-    assert.ok(res.id, 'correct token set');
+    assert.ok(!!res.id, 'correct token set');
   });
 });
 

--- a/tests/unit/services/stripe-test.js
+++ b/tests/unit/services/stripe-test.js
@@ -135,6 +135,97 @@ test('it logs when LOG_STRIPE_SERVICE is set in env config', function(assert) {
   });
 });
 
+test('it card.validateCardNumber return true if credit card number is valid', function (assert) {
+  var service = this.subject();
+  var number = '4111111111111111';
+
+  var isValid = service.card.validateCardNumber(number);
+
+  assert.ok(isValid, 'valid credit card number');
+});
+
+test('it card.validateCardNumber return false if credit card number is invalid', function (assert) {
+  var service = this.subject();
+  var number = '4242111111111111';
+
+  var isValid = service.card.validateCardNumber(number);
+  assert.ok(!isValid, 'invalid credit card number');
+
+  number = '12345678';
+  isValid = service.card.validateCardNumber(number);
+  assert.ok(!isValid, 'invalid credit card number');
+
+  number = 'mistake';
+  isValid = service.card.validateCardNumber(number);
+  assert.ok(!isValid, 'invalid credit card number');
+});
+
+test('it card.cardType returns the type of the card as a string', function (assert) {
+  var service = this.subject();
+
+  var type = service.card.cardType('4242-4242-4242-4242');
+  assert.equal(type, 'Visa');
+
+  type = service.card.cardType('378282246310005');
+  assert.equal(type, 'American Express');
+
+  type = service.card.cardType('1234');
+  assert.equal(type, 'Unknown');
+});
+
+test('it card.validateExpiry returns true if represents an actual month in the future', function (assert) {
+  var service = this.subject();
+
+  var isValid = service.card.validateExpiry('02', '2020');
+  assert.ok(isValid, 'expiry date is valid');
+  isValid = service.card.validateExpiry(2, 2020);
+  assert.ok(isValid, 'expiry date is valid');
+});
+
+test('it card.validateExpiry returns false if not represents an actual month in the future', function (assert) {
+  var service = this.subject();
+  var isValid = service.card.validateExpiry('02', '15');
+
+  assert.ok(!isValid, 'expiry date is invalid');
+  isValid = service.card.validateExpiry(2, 2015);
+  assert.ok(!isValid, 'expiry date is invalid');
+});
+
+test('it bankAccount.validateRoutingNumber returns true if routing number is valid', function (assert) {
+  var service = this.subject();
+
+  var isValid = service.bankAccount.validateRoutingNumber('111000025', 'US');
+  assert.ok(isValid, 'potentially valid routing  number');
+
+  isValid = service.bankAccount.validateRoutingNumber('11111-111', 'CA');
+  assert.ok(isValid, 'potentially valid routing  number');
+
+  isValid = service.bankAccount.validateRoutingNumber('990000000', 'US');
+  assert.ok(isValid, 'potentially valid routing  number');
+});
+
+test('it bankAccount.validateRoutingNumber returns false if routing number is invalid', function (assert) {
+  var service = this.subject();
+
+  var isValid = service.bankAccount.validateRoutingNumber('12345', 'US');
+  assert.ok(!isValid, 'invalid routing number');
+
+  isValid = service.bankAccount.validateRoutingNumber('mistake', 'CA');
+  assert.ok(!isValid, 'invalid routing number');
+});
+
+test('it bankAccount.validateAccountNumber returns true if account number is valid', function (assert) {
+  var service = this.subject();
+  var isValid = service.bankAccount.validateAccountNumber('000123456789', 'US');
+  assert.ok(isValid, 'potentially valid account number');
+});
+
+test('it bankAccount.validateAccountNumber returns false if account number is invalid', function (assert) {
+  var service = this.subject();
+  var isValid = service.bankAccount.validateAccountNumber('mistake', 'US');
+  assert.ok(!isValid, 'invalid account number');
+});
+
 /**
  * @todo figure out how to change env variables at runtime
  */

--- a/tests/unit/services/stripe-test.js
+++ b/tests/unit/services/stripe-test.js
@@ -53,7 +53,7 @@ test('card.createToken rejects the promise if Stripe errors', function(assert) {
 
   return service.card.createToken(cc)
   .then(undefined, function(res) {
-    assert.equal(res, response, 'error passed');
+    assert.deepEqual(res, response, 'error passed');
     createToken.restore();
   });
 });
@@ -109,7 +109,7 @@ test('bankAccount.createToken rejects the promise if Stripe errors', function(as
 
   return service.bankAccount.createToken(ba)
   .then(undefined, function(res) {
-    assert.equal(res, response, 'error passed');
+    assert.deepEqual(res, response, 'error passed');
     createBankAccountToken.restore();
   });
 });


### PR DESCRIPTION
[add] delegate Stripe.card validations to Service.card
[add] add Bank Account Validations
[add] add documentation about validations
[add] add dummy app and integration test reproducing Ember run loop bug

```js
var attr = DS.attr;
export default DS.Model.extend({
  stripe: Ember.inject.service(),
  number: attr('string'),
  cardValidation: function () {
    var card = this.get('stripe.card');
    if (!card.validateCardNumber(this.get('number'))) {
      throw 'Invalid credit card number';
    }
  },
  type: function () {
    var card = this.get('stripe.card');
    return card.cardType(this.get('number'));
  }.property('number')
...
// other validation before token creation
});
```

Also there is an error in test mode which cause stripe's token creation crash on tests even though the call is wrapped in Ember's run loop. you can see it on `tests/dummy` and the tests in `tests/integration`

![screen shot 2015-08-25 at 1 13 31 pm](https://cloud.githubusercontent.com/assets/1157892/9475628/7f1782f0-4b2d-11e5-80f7-9adeda56ba4a.png)
