### PR TITLE
Don’t attempt to initialise when running under FastBoot

### DIFF
--- a/app/initializers/stripe-service.js
+++ b/app/initializers/stripe-service.js
@@ -4,6 +4,10 @@ import config from '../config/environment';
 var debug = config.LOG_STRIPE_SERVICE;
 
 export function initialize() {
+  if (typeof FastBoot !== "undefined") {
+    return;
+  }
+
   if (debug) {
     Ember.Logger.info('StripeService: initialize');
   }


### PR DESCRIPTION
This lets apps run under fastboot which have this addon installed

Obviously the addon will no longer work in Fastboot, but I don't see a scenario where that would be wanted anyway!