### PR TITLE
[feature] Adds support for creating personally identifiable information (PII) data tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,35 @@ The interface is similar for bank account tokens:
 })
 ````
 
+## Creating Stripe Tokens for PII Data
+
+The interface is similar yet again for PII data tokens:
+
+````javascript
+
+    // obtain access to the injected service
+    var stripe = this.get('stripe');
+
+    var piiData = {
+      personalIdNumber: '123456789'
+    }
+
+    return stripe.piiData.createToken(piiData).then(function(response) {
+      // you get access to your newly created token here
+      customer.set('personalIdNumberStripeToken', response.id);
+      return customer.save();
+    })
+    .catch(response) {
+      // if there was an error retrieving the token you could get it here
+
+      if (response.error.type === 'invalid_request_error') {
+        // show an error in the form
+      }
+    }
+  }
+})
+````
+
 ## Debugging
 By setting `LOG_STRIPE_SERVICE` to true in your application configuration you can enable some debugging messages from the service
 

--- a/addon/services/stripe.js
+++ b/addon/services/stripe.js
@@ -13,6 +13,10 @@ export default Ember.Service.extend({
       createToken: this._createBankAccountToken.bind(this)
     };
 
+    this.piiData = {
+      createToken: this._createPiiDataToken.bind(this)
+    };
+
     this._checkForAndAddCardFn('cardType', Stripe.card.cardType);
     this._checkForAndAddCardFn('validateCardNumber', Stripe.card.validateCardNumber);
     this._checkForAndAddCardFn('validateCVC', Stripe.card.validateCVC);
@@ -64,6 +68,30 @@ export default Ember.Service.extend({
         }
       });
     });
+  },
+
+  /**
+   * Creates a piiData token using Stripe.js API, exposed as `piiData.createToken`
+   * @param  {object} piiData  PiiData
+   * @return {promise}         Returns a promise that holds response, see stripe.js docs for details
+   *                           status is not being returned at the moment but it can be logged
+   */
+  _createPiiDataToken(piiData) {
+    this.debug('piiData.createToken:', piiData);
+
+    return new Ember.RSVP.Promise((resolve, reject) => {
+      Stripe.piiData.createToken(piiData, (status, response) => {
+
+        this.debug('piiData.createToken handler - status %s, response:', status, response);
+
+        if (response.error) {
+          reject(response);
+        } else {
+          resolve(response);
+        }
+      });
+    });
+
   },
 
   /**

--- a/package.json
+++ b/package.json
@@ -23,6 +23,10 @@
     {
       "name": "Sam Selikoff",
       "email": "sam.selikoff@gmail.com"
+    },
+    {
+      "name": "Jordan Killpack",
+      "email": "jordan@bignerdranch.com"
     }
   ],
   "license": "MIT",

--- a/tests/integration/stripe-test.js
+++ b/tests/integration/stripe-test.js
@@ -22,6 +22,10 @@ var bankAccount= {
   accountNumber: '000123456789',
 };
 
+var piiData = {
+  personalIdNumber: '123456789'
+};
+
 Stripe.setPublishableKey(env.stripe.publishableKey);
 
 test('card.createToken sets the token and returns a promise', function(assert) {
@@ -37,6 +41,15 @@ test('bankAccount.createToken sets the token and returns a promise', function(as
   var service = this.subject();
 
   return service.bankAccount.createToken(bankAccount)
+  .then(function(res) {
+    assert.ok(res.id, 'correct token set');
+  });
+});
+
+test('piiData.createToken sets the token and returns a promise', function(assert) {
+  var service = this.subject();
+
+  return service.piiData.createToken(piiData)
   .then(function(res) {
     assert.ok(res.id, 'correct token set');
   });

--- a/tests/unit/services/stripe-test.js
+++ b/tests/unit/services/stripe-test.js
@@ -109,3 +109,54 @@ test('bankAccount.createToken rejects the promise if Stripe errors', function(as
       createBankAccountToken.restore();
     });
 });
+
+// PII Data
+//
+var pii = {
+  personalIdNumber: '123456779'
+};
+
+test('piiData.createToken sets the token and returns a promise', function(assert) {
+  var service = this.subject();
+  var response = {
+    id: 'the_token'
+  };
+
+  var createPiiDataToken = sinon.stub(
+    Stripe.piiData,
+    'createToken',
+    function(piiData, cb) {
+      assert.equal(piiData, pii, 'called with sample piiData');
+      cb(200, response);
+    }
+  );
+
+  return service.piiData.createToken(pii)
+    .then(function(res) {
+      assert.equal(res.id, 'the_token');
+      createPiiDataToken.restore();
+    });
+});
+
+test('piiData.createToken rejects the promise if Stripe errors', function(assert) {
+  var service = this.subject();
+  var response = {
+    error : {
+      type: "api_error"
+    }
+  };
+
+  var createPiiDataToken = sinon.stub(
+    Stripe.piiData,
+    'createToken',
+    function(piiData, cb) {
+      cb(500, response);
+    }
+  );
+
+  return service.piiData.createToken(ba)
+    .catch((res) => {
+      assert.equal(res, response, 'error passed');
+      createPiiDataToken.restore();
+    });
+});


### PR DESCRIPTION
PII data tokens allow you to pass sensitive information (such as social security numbers) to Stripe via your backend server without the danger associated with letting such information make it to your servers in plaintext. 

Here's a typical use case: if you have a sales platform, you will need to create a Stripe managed account for your sellers on your backend. Stripe requires you to provide certain identity verification information, which may include a social security number. Since it's risky to have plaintext SSNs touch your server, you can first send this data straight to Stripe via the method exposed in this PR, and then you can send the returned token to your backend to complete the identity verification process.